### PR TITLE
Update .travis.yml to build on all Rusts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,14 @@
 language: rust
+
+rust:
+  - nightly
+  - beta
+  - stable
+
+matrix:
+  allow_failures:
+    - rust: nightly
+
 script:
   - cargo build -v
   - cargo doc -v


### PR DESCRIPTION
Hey there! I noticed this crate on the last crater report: https://internals.rust-lang.org/t/new-crater-reports-1-1-stable-vs-beta-2015-07-10-and-nightly-2015-07-10/2358

It seems like you've fixed the build since then, but I added a Travis matrix that will test against all three channels, just to check.
