### PR TITLE
Add documentation link to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/PistonDevelopers/dev_menu"
 homepage = "https://github.com/PistonDevelopers/dev_menu"
+documentation = "http://www.piston.rs/docs/dev_menu/dev_menu/"
 
 [dependencies]
 


### PR DESCRIPTION
There is currently no link to the documentation on the crates.io page. This will add the documentation link.
